### PR TITLE
Update additional inspect rules and validators

### DIFF
--- a/lhc-form-inspect-helpers.ts
+++ b/lhc-form-inspect-helpers.ts
@@ -6,7 +6,12 @@
  * convenience.
  */
 
-import { inspect as insp, nihLhcForms as lf, safety } from "./deps.ts";
+import {
+  inspect as insp,
+  inspText,
+  nihLhcForms as lf,
+  safety,
+} from "./deps.ts";
 
 export interface LhcFormItemInspectionResult<
   F extends lf.NihLhcForm = lf.NihLhcForm,
@@ -82,7 +87,7 @@ export function isNumericValues(
 
 export function isBooleanValue(
   value: lf.ValueElement | lf.ValueElement[],
-): value is number {
+): value is boolean {
   switch (typeof value) {
     case "boolean":
       return true;
@@ -116,7 +121,7 @@ export function isTextValue(
 
 export function isTextValues(
   value: lf.ValueElement | lf.ValueElement[],
-  testAll: boolean,
+  testAll: string,
 ): value is string[] {
   if (Array.isArray(value)) {
     return value.find((v) => !isTextValue(v)) ? false : true;
@@ -139,10 +144,19 @@ export function inspectRequiredFormItem<
   } else if (value == "" || value == null) {
     return lf.lchFormItemIssue(form, item, "Value required");
   } else if (isConstrainedValues(value)) {
-    console.log("Is an array of constraints");
+    //Is an array of constraints
+    value.find((v) => {
+      if (v.text == "" || v.code == "" || v.text == null || v.code == null) {
+        return lf.lchFormItemIssue(form, item, "Value required");
+      }
+    });
   } else if (isConstrainedValue(value)) {
-    console.log(value.text);
-    console.log(value.code);
+    if (
+      value.text == "" || value.text == null || value.code == "" ||
+      value.code == null
+    ) {
+      return lf.lchFormItemIssue(form, item, "Value required");
+    }
   }
 
   return item;
@@ -168,4 +182,222 @@ export function isConstrainedListItemNotSingleValue<
   match: lf.ConstrainedListItemValue,
 ): match is V {
   return !isConstrainedListItemSingleValue<V>(o, match);
+}
+
+export async function inspectFacebookURL(
+  target: inspText.TextValue | inspText.TextInspectionResult,
+): Promise<
+  | inspText.TextValue
+  | inspText.TextInspectionResult
+  | inspText.TextInspectionIssue
+> {
+  const it: inspText.TextValue = inspText.isTextInspectionResult(target)
+    ? target.inspectionTarget
+    : target;
+  const url = inspText.resolveTextValue(it);
+  if (!url || url.length == 0) {
+    return it;
+  }
+  const siteCollectionDetector = "facebook.com/";
+  if (url.indexOf(siteCollectionDetector) >= 0) {
+    return inspText.textIssue(
+      it,
+      `${url} is not a valid facebook url`,
+    );
+  }
+  try {
+    const urlFetch = await fetch(url);
+    if (urlFetch.status != 200) {
+      return inspText.textIssue(
+        it,
+        `${url} did not return valid status: ${urlFetch.statusText}`,
+      );
+    }
+  } catch (err) {
+    return inspText.textIssue(
+      it,
+      `Exception while trying to fetch ${url}: ${err}`,
+    );
+  }
+
+  // no errors found, return untouched
+  return target;
+}
+
+export async function inspectTwitterURL(
+  target: inspText.TextValue | inspText.TextInspectionResult,
+): Promise<
+  | inspText.TextValue
+  | inspText.TextInspectionResult
+  | inspText.TextInspectionIssue
+> {
+  const it: inspText.TextValue = inspText.isTextInspectionResult(target)
+    ? target.inspectionTarget
+    : target;
+  const url = inspText.resolveTextValue(it);
+  if (!url || url.length == 0) {
+    return it;
+  }
+  const siteCollectionDetector = "twitter.com/";
+  if (url.indexOf(siteCollectionDetector) >= 0) {
+    return inspText.textIssue(
+      it,
+      `${url} is not a valid twitter url`,
+    );
+  }
+  try {
+    const urlFetch = await fetch(url);
+    if (urlFetch.status != 200) {
+      return inspText.textIssue(
+        it,
+        `${url} did not return valid status: ${urlFetch.statusText}`,
+      );
+    }
+  } catch (err) {
+    return inspText.textIssue(
+      it,
+      `Exception while trying to fetch ${url}: ${err}`,
+    );
+  }
+
+  // no errors found, return untouched
+  return target;
+}
+
+export async function inspectLinkedInURL(
+  target: inspText.TextValue | inspText.TextInspectionResult,
+): Promise<
+  | inspText.TextValue
+  | inspText.TextInspectionResult
+  | inspText.TextInspectionIssue
+> {
+  const it: inspText.TextValue = inspText.isTextInspectionResult(target)
+    ? target.inspectionTarget
+    : target;
+  const url = inspText.resolveTextValue(it);
+  if (!url || url.length == 0) {
+    return it;
+  }
+  const siteCollectionDetector = "linkedin.com/";
+  if (url.indexOf(siteCollectionDetector) >= 0) {
+    return inspText.textIssue(
+      it,
+      `${url} is not a valid linkedin url`,
+    );
+  }
+  try {
+    const urlFetch = await fetch(url);
+    if (urlFetch.status != 200) {
+      return inspText.textIssue(
+        it,
+        `${url} did not return valid status: ${urlFetch.statusText}`,
+      );
+    }
+  } catch (err) {
+    return inspText.textIssue(
+      it,
+      `Exception while trying to fetch ${url}: ${err}`,
+    );
+  }
+
+  // no errors found, return untouched
+  return target;
+}
+
+export async function inspectInstagramURL(
+  target: inspText.TextValue | inspText.TextInspectionResult,
+): Promise<
+  | inspText.TextValue
+  | inspText.TextInspectionResult
+  | inspText.TextInspectionIssue
+> {
+  const it: inspText.TextValue = inspText.isTextInspectionResult(target)
+    ? target.inspectionTarget
+    : target;
+  const url = inspText.resolveTextValue(it);
+  if (!url || url.length == 0) {
+    return it;
+  }
+  const siteCollectionDetector = "instagram.com/";
+  if (url.indexOf(siteCollectionDetector) >= 0) {
+    return inspText.textIssue(
+      it,
+      `${url} is not a valid instagram url`,
+    );
+  }
+  try {
+    const urlFetch = await fetch(url);
+    if (urlFetch.status != 200) {
+      return inspText.textIssue(
+        it,
+        `${url} did not return valid status: ${urlFetch.statusText}`,
+      );
+    }
+  } catch (err) {
+    return inspText.textIssue(
+      it,
+      `Exception while trying to fetch ${url}: ${err}`,
+    );
+  }
+
+  // no errors found, return untouched
+  return target;
+}
+
+export async function inspectEmailAddress(
+  target: inspText.TextValue | inspText.TextInspectionResult,
+): Promise<
+  | inspText.TextValue
+  | inspText.TextInspectionResult
+  | inspText.TextInspectionIssue
+> {
+  const it: inspText.TextValue = inspText.isTextInspectionResult(target)
+    ? target.inspectionTarget
+    : target;
+  const email = inspText.resolveTextValue(it);
+  if (!email || email.length == 0) {
+    return it;
+  }
+  /* Check if the email is valid using 
+   * tools like https://email-checker.net 
+   */
+  try {
+    /* Check if email exists */
+  } catch (err) {
+    return inspText.textIssue(
+      it,
+      `Exception while trying to verify ${email}: ${err}`,
+    );
+  }
+
+  // no errors found, return untouched
+  return target;
+}
+
+export async function inspectPhoneNumberUSFormat(
+  target: inspText.TextValue | inspText.TextInspectionResult,
+): Promise<
+  | inspText.TextValue
+  | inspText.TextInspectionResult
+  | inspText.TextInspectionIssue
+> {
+  const it: inspText.TextValue = inspText.isTextInspectionResult(target)
+    ? target.inspectionTarget
+    : target;
+  const phoneNumber = inspText.resolveTextValue(it);
+  if (!phoneNumber || phoneNumber.length == 0) {
+    return it;
+  }
+  /* Check if the phone number formatting is US */
+  try {
+    /* Check if phone number exists */
+  } catch (err) {
+    return inspText.textIssue(
+      it,
+      `Exception while trying to verify ${phoneNumber}: ${err}`,
+    );
+  }
+
+  // no errors found, return untouched
+  return target;
 }

--- a/offering-profile/lform.ts
+++ b/offering-profile/lform.ts
@@ -658,27 +658,49 @@ async function inspectSocialPresence(
     : target;
   const sp: SocialPresence = opf.items[2];
   const ancestors = [sp];
-
+  const diags = new lf.TypicalLhcFormInspectionDiags<OfferingProfileLhcForm>(
+    insp.defaultInspectionContext(),
+  );
   /* Facebook URL, to be verified in Facebook
    * Validate with reference source site 
    */
   const facebookLink: SocialPresenceFacebookLink = sp.items[0];
-
+  diags.onFormItemInspection(
+    opf,
+    facebookLink,
+    await lfih.inspectFacebookURL(facebookLink.value),
+    ancestors,
+  );
   /* Twitter URL, to be verified in Twitter
    * Validate with reference source site 
    */
   const twitterLink: SocialPresenceTwitterLink = sp.items[1];
-
+  diags.onFormItemInspection(
+    opf,
+    twitterLink,
+    await lfih.inspectTwitterURL(twitterLink.value),
+    ancestors,
+  );
   /* LinkedIn URL, to be verified in LinkedIn
    * Validate with reference source site 
    */
   const linkedInLink: SocialPresenceLinkedInLink = sp.items[2];
-
+  diags.onFormItemInspection(
+    opf,
+    linkedInLink,
+    await lfih.inspectLinkedInURL(linkedInLink.value),
+    ancestors,
+  );
   /* Instagram URL, to be verified in Instagram
    * Validate with reference source site 
    */
   const instagramLink: SocialPresenceInstagramLink = sp.items[3];
-
+  diags.onFormItemInspection(
+    opf,
+    instagramLink,
+    await lfih.inspectInstagramURL(instagramLink.value),
+    ancestors,
+  );
   // we didn't modify the target, we added issues to diagnostics
   return target;
 }
@@ -695,23 +717,46 @@ async function inspectRespondentContactInformation(
     : target;
   const rci: RespondentContactInformation = opf.items[0];
   const ancestors = [rci];
+  const diags = new lf.TypicalLhcFormInspectionDiags<OfferingProfileLhcForm>(
+    insp.defaultInspectionContext(),
+  );
 
   // Check for the email verification using tools like https://email-checker.net
   const respondantEmail: RespondentEmailAddress = rci.items[1];
-
+  diags.onFormItemInspection(
+    opf,
+    respondantEmail,
+    await lfih.inspectEmailAddress(respondantEmail.value),
+    ancestors,
+  );
   // Check for the email verification using tools like https://email-checker.net
   const respondantVendorEmail: RespondentVendorEmailAddress = rci.items[4];
-
+  diags.onFormItemInspection(
+    opf,
+    respondantVendorEmail,
+    await lfih.inspectEmailAddress(respondantVendorEmail.value),
+    ancestors,
+  );
   /* Check for US number formatting
    * Validate with reference source site if possible
    */
   const respondantContactNumber: RespondentContactPhoneNumber = rci.items[2];
-
+  diags.onFormItemInspection(
+    opf,
+    respondantContactNumber,
+    await lfih.inspectPhoneNumberUSFormat(respondantContactNumber.value),
+    ancestors,
+  );
   /* Check for US number formatting
    * Validate with reference source site if possible
    */
   const respondantVendorContact: RespondentVendorPhoneNumber = rci.items[5];
-
+  diags.onFormItemInspection(
+    opf,
+    respondantVendorContact,
+    await lfih.inspectPhoneNumberUSFormat(respondantVendorContact.value),
+    ancestors,
+  );
   // we didn't modify the target, we added issues to diagnostics
   return target;
 }


### PR DESCRIPTION
Added following methods in LHC form inspect helpers (`lhc-form-inspect-helpers.ts`)  and its corresponding changes in lform.ts of offering profile

- inspectFacebookURL
- inspectTwitterURL
- inspectLinkedInURL
- inspectInstagramURL
- inspectEmailAddress
- inspectPhoneNumberUSFormat

